### PR TITLE
Fix ".kol" extension check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,7 +16,7 @@ func main() {
 		return
 	} else if len(os.Args) == 3 && os.Args[1] == "run:" {
 		filePath := os.Args[2]
-		if filePath[len(filePath)-3:] != ".kol" {
+		if filePath[len(filePath)-4:] != ".kol" {
 			fmt.Println("Error: File should have .kol extension")
 			return
 		}


### PR DESCRIPTION
Hello!

I have identified that the code responsible for checking the .kol extension uses len(filePath)-3, which is not enough, since the extension has 4 characters.

I implemented the following correction in the section:
``` bash
if filePath[len(filePath)-4:] != ".kol" {
    fmt.Println("Error: File should have .kol extension")
    return
}
```
This ensures that the program correctly validates files with the .kol extension.